### PR TITLE
- Changed Menu organization to make the Main menu have sub-menus

### DIFF
--- a/src/config.yml
+++ b/src/config.yml
@@ -46,22 +46,28 @@ menu:
     theme: 'RAINBOW'
     items:
       - 'BLUE_STAINED_GLASS_PANE'
-      - 'YELLOW_STAINED_GLASS_PANE'
       - 'GREEN_STAINED_GLASS_PANE'
-      - 'ORANGE_STAINED_GLASS_PANE'
       - 'PURPLE_STAINED_GLASS_PANE'
+  particle:
+    theme: 'RAINBOW'
+    items:
+      - 'YELLOW_STAINED_GLASS_PANE'
+      - 'ORANGE_STAINED_GLASS_PANE'
       - 'LIME_STAINED_GLASS_PANE'
+  settings:
+    theme: 'SOLID'
+    items: 'LIME_STAINED_GLASS_PANE'
   crown:
-    theme: 'STATIC'
+    theme: 'SOLID'
     items: 'YELLOW_STAINED_GLASS_PANE'
   aura:
-    theme: 'STATIC'
+    theme: 'SOLID'
     items: 'PURPLE_STAINED_GLASS_PANE'
   wings:
-    theme: 'STATIC'
+    theme: 'SOLID'
     items: 'GREEN_STAINED_GLASS_PANE'
   orb:
-    theme: 'STATIC'
+    theme: 'SOLID'
     items: 'LIME_STAINED_GLASS_PANE'
 
 

--- a/src/fancy/FancyPlayer.java
+++ b/src/fancy/FancyPlayer.java
@@ -20,6 +20,9 @@ public class FancyPlayer {
     public Gadget gadget;
     public Pet pet;
 
+    //Settings
+    public boolean canSeeOwnParticles;
+
     /**
      * PartlyFancy's player object
      * @param p Player to create object for
@@ -29,6 +32,7 @@ public class FancyPlayer {
         this.gadget = null;
         this.pet = null;
         this.playerUUID = p.getUniqueId();
+        this.canSeeOwnParticles = false;
         PartlyFancy.getFancyPlayers().put(this.playerUUID, this);
     }
 

--- a/src/fancy/PartlyFancy.java
+++ b/src/fancy/PartlyFancy.java
@@ -88,6 +88,8 @@ public class PartlyFancy extends JavaPlugin implements Listener {
     public void onPlayerLeave(PlayerQuitEvent event) {
         Player p = event.getPlayer();
 
+        FancyPlayer.getFancyPlayer(p).stopParticle();
+
         getFancyPlayers().remove(p.getUniqueId());
     }
 

--- a/src/fancy/command/CmdMenu.java
+++ b/src/fancy/command/CmdMenu.java
@@ -13,7 +13,7 @@ public class CmdMenu implements FancyCommandLoader.FancyCommand {
         FancyPlayer fancyPlayer = FancyPlayer.getFancyPlayer(player);
 
         if (player.hasPermission(permission())) {
-            FancyMenuLoader.openMenu(player, FancyMenuLoader.getFromId(0), true);
+            FancyMenuLoader.openMenu(player, FancyMenuLoader.getFromId(FancyMenuLoader.FancyMenuIds.MAIN.getId()), true);
             return 1;
         } else {
             fancyPlayer.sendMessage(PartlyFancy.getValue("message.command.no-permission",

--- a/src/fancy/cosmetics/Particle.java
+++ b/src/fancy/cosmetics/Particle.java
@@ -8,7 +8,8 @@ public interface Particle extends FancyCosmetic {
 
     ParticleType getType();
 
-    int interval();
+
+    void run(double... steps);
 
     enum ParticleType {
         CROWN, SPIRAL, SPIKE, AURA, SCAN, WINGS, ORB

--- a/src/fancy/cosmetics/particles/CrownParticle.java
+++ b/src/fancy/cosmetics/particles/CrownParticle.java
@@ -1,6 +1,7 @@
 package fancy.cosmetics.particles;
 
 import com.sun.istack.internal.NotNull;
+import fancy.FancyPlayer;
 import fancy.PartlyFancy;
 import fancy.cosmetics.Particle;
 import fancy.util.FancyUtil;
@@ -12,23 +13,56 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class CrownParticle implements Particle {
 
-    private boolean enabled;
+    public static List<FancyPlayer> crownParticleUsers = new ArrayList<>();
+
+    private static double radius = 0.7D;
+    private static double amount = radius * 60.0D;
+    private static double inc = (Math.PI * 4) / amount;
+    private static int i = 0;
+    public static int interval = 2;
+
+
+    static {
+        new BukkitRunnable() {
+
+            @Override
+            public void run() {
+
+
+                if (crownParticleUsers.size() > 0) {
+
+                    for (FancyPlayer fp : crownParticleUsers) {
+
+                        fp.particleEffect.run(i);
+
+                    }
+                }
+
+                if (i >= amount - 1.0D) {
+                    i = 0;
+                } else i += 1;
+
+            }
+
+        }.runTaskTimer(PartlyFancy.getInstance(), 0, interval);
+    }
+
     private Player player;
     private Particles[] effects;
-    private int i;
 
     /**
-     * A crown affect is a basic ring over a player's head
+     * An aura affect is a basic ring over a player's head
      * @param player Player to attach effect to
      * @param effects Particles to be displayed
      */
     public CrownParticle(@NotNull Player player, @NotNull Particles... effects) {
-        this.enabled = true;
         this.player = player;
         this.effects = effects;
-        this.i = 0;
     }
 
     @Override
@@ -38,7 +72,7 @@ public class CrownParticle implements Particle {
 
     @Override
     public ParticleType getType() {
-        return ParticleType.CROWN;
+        return ParticleType.AURA;
     }
 
     @Override
@@ -48,53 +82,45 @@ public class CrownParticle implements Particle {
 
     @Override
     public String name() {
-        return "Crown Particle";
+        return "Aura Particle";
     }
 
     @Override
     public void start() {
-        new BukkitRunnable() {
-            @Override
-            public void run() {
 
-                if (!getPlayer().isOnline() || !enabled) {
-                    stop();
-                    return;
-                }
+        crownParticleUsers.add(FancyPlayer.getFancyPlayer(this.getPlayer()));
 
-                double radius = 0.7D;
-                double amount = radius * 30.0D;
-                double inc = (Math.PI * 4) / amount;
-                double angle = i * inc;
-
-                double x = radius * Math.cos(angle);
-                double z = radius * Math.sin(angle);
-
-                Vector v = new Vector(x, 2.35D, z);
-                Location loc = getPlayer().getLocation().add(v);
-
-                for (Particles particle : getParticles()) {
-                    if (particle != null) {
-                        particle.display(loc, 5);
-                    }
-                }
-
-                if (i >= (amount - 1.0D)) {
-                    i = 0;
-                } else i++;
-
-            }
-        }.runTaskTimer(PartlyFancy.getInstance(), 10, interval());
-    }
-
-    @Override
-    public int interval() {
-        return 2;
     }
 
     @Override
     public void stop() {
-        this.enabled = false;
+
+        crownParticleUsers.remove(FancyPlayer.getFancyPlayer(this.getPlayer()));
+
+    }
+
+
+    @Override
+    public void run(double... step) {
+
+        double angle = step[0] * inc;
+
+        double x = radius * Math.cos(angle);
+        double z = radius * Math.sin(angle);
+
+        Vector v = new Vector(x, 2.35D, z);
+        Location loc = getPlayer().getLocation().add(v);
+
+        for (Particles particle : getParticles()) {
+            if (particle != null) {
+                particle.display(FancyPlayer.getFancyPlayer(this.getPlayer()), loc, 5);
+            }
+        }
+
+        if (i >= (amount - 1.0D)) {
+            i = 0;
+        } else i++;
+
     }
 
     public static ItemStack item() {

--- a/src/fancy/cosmetics/particles/OrbParticle.java
+++ b/src/fancy/cosmetics/particles/OrbParticle.java
@@ -1,6 +1,7 @@
 package fancy.cosmetics.particles;
 
 import com.sun.istack.internal.NotNull;
+import fancy.FancyPlayer;
 import fancy.PartlyFancy;
 import fancy.cosmetics.Particle;
 import fancy.util.FancyUtil;
@@ -12,9 +13,33 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class OrbParticle implements Particle {
 
-    private boolean enabled;
+    public static List<FancyPlayer> orbParticleUsers = new ArrayList<>();
+    public static int interval = 15;
+
+    static {
+        new BukkitRunnable() {
+
+            @Override
+            public void run() {
+
+                if (orbParticleUsers.size() > 0) {
+
+                    for (FancyPlayer fp : orbParticleUsers) {
+
+                        fp.particleEffect.run(-1);
+
+                    }
+                }
+            }
+
+        }.runTaskTimer(PartlyFancy.getInstance(), 0, interval);
+    }
+
     private Player player;
     private Particles[] effects;
 
@@ -24,7 +49,6 @@ public class OrbParticle implements Particle {
      * @param effects Particles to be displayed
      */
     public OrbParticle(@NotNull Player player, @NotNull Particles... effects) {
-        this.enabled = true;
         this.player = player;
         this.effects = effects;
     }
@@ -51,48 +75,41 @@ public class OrbParticle implements Particle {
 
     @Override
     public void start() {
-        new BukkitRunnable() {
-            @Override
-            public void run() {
 
-                if (!getPlayer().isOnline() || !enabled) {
-                    stop();
-                    return;
-                }
+        orbParticleUsers.add(FancyPlayer.getFancyPlayer(this.getPlayer()));
 
-                double radius = 1.2D;
-                double amount = radius * 30.0D;
-                double inc = (Math.PI * 4) / amount;
-
-                for (int i = 0; i < 180; i++) {
-
-                    double angle = i * inc;
-
-                    double x = radius * Math.cos(angle);
-                    double z = radius * Math.sin(angle);
-
-                    Vector v = FancyUtil.rotateVectorDegree(new Vector(x, z + 1, 0), (i * 18));
-                    Location loc = getPlayer().getLocation().add(v);
-
-                    for (Particles particle : getParticles()) {
-                        if (particle != null) {
-                            particle.display(loc, 5);
-                        }
-                    }
-                }
-
-            }
-        }.runTaskTimer(PartlyFancy.getInstance(), 10, interval());
     }
 
     @Override
-    public int interval() {
-        return 15;
+    public void run(double... step) {
+
+        double radius = 1.2D;
+        double amount = radius * 30.0D;
+        double inc = (Math.PI * 4) / amount;
+
+        for (int i = 0; i < 180; i++) {
+
+            double angle = i * inc;
+
+            double x = radius * Math.cos(angle);
+            double z = radius * Math.sin(angle);
+
+            Vector v = FancyUtil.rotateVectorDegree(new Vector(x, z + 1, 0), (i * 18)).multiply(1.3f);
+            Location loc = getPlayer().getLocation().add(v);
+
+            for (Particles particle : getParticles()) {
+                if (particle != null) {
+                    particle.display(FancyPlayer.getFancyPlayer(this.getPlayer()), loc, 5);
+                }
+            }
+        }
     }
 
     @Override
     public void stop() {
-        this.enabled = false;
+
+        orbParticleUsers.remove(FancyPlayer.getFancyPlayer(this.getPlayer()));
+
     }
 
     public static ItemStack item() {

--- a/src/fancy/menu/FancyMenuLoader.java
+++ b/src/fancy/menu/FancyMenuLoader.java
@@ -1,7 +1,15 @@
 package fancy.menu;
 
 import fancy.PartlyFancy;
-import fancy.menu.menus.*;
+import fancy.menu.menus.MainMenu;
+import fancy.menu.menus.ParticleMenu;
+import fancy.menu.menus.SettingsMenu;
+import fancy.menu.menus.particle.AuraMenu;
+import fancy.menu.menus.particle.CrownMenu;
+import fancy.menu.menus.particle.OrbMenu;
+import fancy.menu.menus.particle.WingsMenu;
+import fancy.menu.themes.Rainbow;
+import fancy.menu.themes.Solid;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.permissions.Permission;
@@ -12,10 +20,20 @@ import java.util.List;
 public class FancyMenuLoader {
 
     public static List<FancyMenu> menus = new ArrayList<>();
+    public static List<FancyMenuTheme> themes = new ArrayList<>();
 
     static {
 
+        //Themes
+        addTheme(new Solid(true));
+        addTheme(new Rainbow(true));
+
+        // Main Menus
         registerFancyMenu(new MainMenu());
+        registerFancyMenu(new ParticleMenu());
+        registerFancyMenu(new SettingsMenu());
+
+        // Particle Menus
         registerFancyMenu(new CrownMenu());
         registerFancyMenu(new AuraMenu());
         registerFancyMenu(new WingsMenu());
@@ -55,8 +73,32 @@ public class FancyMenuLoader {
         }
     }
 
+    public enum FancyMenuIds {
+
+        MAIN(1), PARTICLE(2), SETTINGS(3),
+
+        PARTICLE_CROWN(20), PARTICLE_AURA(21), PARTICLE_ORB(22), PARTICLE_WINGS(23);
+
+        int id;
+        FancyMenuIds(int id) {
+            this.id = id;
+        }
+
+        public String getIdString() {
+            return Integer.toString(id);
+        }
+
+        public int getId() {
+            return id;
+        }
+    }
+
     public static void registerFancyMenu(FancyMenu m) {
         menus.add(m);
+    }
+
+    static void addTheme(FancyMenuTheme theme) {
+        themes.add(theme);
     }
 
     public static FancyMenu getFromId(int id) {
@@ -95,4 +137,5 @@ public class FancyMenuLoader {
         FancyMenuTheme getTheme();
 
     }
+
 }

--- a/src/fancy/menu/events/MenuEvents.java
+++ b/src/fancy/menu/events/MenuEvents.java
@@ -44,7 +44,7 @@ public class MenuEvents implements Listener {
                         value = NBTUtil.getItemTag(item, "PartlyFancy", "goback");
                     }
 
-                    FancyMenuLoader.FancyMenu inv = FancyMenuLoader.getFromId(Integer.parseInt(value.toString()));
+                    FancyMenuLoader.FancyMenu inv = FancyMenuLoader.getFromId((int) value);
 
                     if (inv.getInventory() == null) {
                         p.sendMessage(PartlyFancy.getValue("message.menu.not-found", "%id%-" + value.toString()));

--- a/src/fancy/menu/menus/ParticleMenu.java
+++ b/src/fancy/menu/menus/ParticleMenu.java
@@ -1,0 +1,92 @@
+package fancy.menu.menus;
+
+import fancy.cosmetics.particles.AuraParticle;
+import fancy.cosmetics.particles.CrownParticle;
+import fancy.cosmetics.particles.OrbParticle;
+import fancy.cosmetics.particles.WingsParticle;
+import fancy.menu.FancyMenuLoader;
+import fancy.menu.FancyMenuTheme;
+import fancy.util.FancyUtil;
+import fancy.util.NBTUtil;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.permissions.Permission;
+
+public class ParticleMenu implements FancyMenuLoader.FancyMenu {
+
+    private Inventory inv;
+
+    public ParticleMenu() {
+        this.inv = Bukkit.createInventory(null, 54, this.getName());
+        this.getTheme().apply();
+    }
+
+    @Override
+    public Integer inventoryId() {
+        return FancyMenuLoader.FancyMenuIds.PARTICLE.getId();
+    }
+
+    @Override
+    public FancyMenuLoader.FancyMenu getInstance() {
+        return this;
+    }
+
+    @Override
+    public Inventory getInventory() {
+        inv.setItem(10,
+                NBTUtil.setItemTag(
+                        CrownParticle.item(),
+                        FancyMenuLoader.FancyMenuIds.PARTICLE_CROWN.getId(),
+                        "PartlyFancy", "openinv"
+                ));
+        inv.setItem(13,
+                NBTUtil.setItemTag(
+                        AuraParticle.item(),
+                        FancyMenuLoader.FancyMenuIds.PARTICLE_AURA.getId(),
+                        "PartlyFancy", "openinv"
+                ));
+        inv.setItem(16,
+                NBTUtil.setItemTag(
+                        WingsParticle.item(),
+                        FancyMenuLoader.FancyMenuIds.PARTICLE_WINGS.getId(),
+                        "PartlyFancy", "openinv"
+                ));
+        inv.setItem(29,
+                NBTUtil.setItemTag(
+                        OrbParticle.item(),
+                        FancyMenuLoader.FancyMenuIds.PARTICLE_ORB.getId(),
+                        "PartlyFancy", "openinv"
+                ));
+        inv.setItem(48,
+                NBTUtil.setItemTag(
+                        FancyUtil.createItemStack(Material.ARROW, 1, "&cGo Back", null, "&7Go back a menu.."),
+                        FancyMenuLoader.FancyMenuIds.MAIN.getId(),
+                        "PartlyFancy", "goback"
+                ));
+        inv.setItem(49,
+                NBTUtil.setItemTag(
+                        FancyUtil.createItemStack(Material.BARRIER, 1, "&cClose Menu", null, "&7Close this menu.."),
+                        "null",
+                        "PartlyFancy", "close"
+                ));
+
+        return this.inv;
+    }
+
+    @Override
+    public String getName() {
+        return ChatColor.BLACK + "Fancy Particle Menu";
+    }
+
+    @Override
+    public Permission permission() {
+        return new Permission("fancy.menu.particle", "Permission to the particle fancy menu.");
+    }
+
+    @Override
+    public FancyMenuTheme getTheme() {
+        return FancyMenuTheme.parseTheme(this, "menu.particle");
+    }
+}

--- a/src/fancy/menu/menus/SettingsMenu.java
+++ b/src/fancy/menu/menus/SettingsMenu.java
@@ -8,23 +8,20 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.inventory.Inventory;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.permissions.Permission;
 
-import java.util.List;
-
-public class AuraMenu implements FancyMenuLoader.FancyMenu {
+public class SettingsMenu implements FancyMenuLoader.FancyMenu {
 
     private Inventory inv;
 
-    public AuraMenu() {
+    public SettingsMenu() {
         this.inv = Bukkit.createInventory(null, 54, this.getName());
         this.getTheme().apply();
     }
 
     @Override
     public Integer inventoryId() {
-        return 2;
+        return FancyMenuLoader.FancyMenuIds.SETTINGS.getId();
     }
 
     @Override
@@ -35,26 +32,12 @@ public class AuraMenu implements FancyMenuLoader.FancyMenu {
     @Override
     public Inventory getInventory() {
 
-        List<ItemStack> items = FancyUtil.generateParticleItems("aura_particle");
-
-        int index = 0;
-        for (int i = 20; i < 34; i++) {
-
-            inv.setItem(i, items.get(index));
-
-            index++;
-            if (i == 24) {
-                i = 28;
-            }
-        }
-
         inv.setItem(48,
                 NBTUtil.setItemTag(
                         FancyUtil.createItemStack(Material.ARROW, 1, "&cGo Back", null, "&7Go back a menu.."),
-                        0,
+                        FancyMenuLoader.FancyMenuIds.MAIN.getId(),
                         "PartlyFancy", "goback"
                 ));
-
         inv.setItem(49,
                 NBTUtil.setItemTag(
                         FancyUtil.createItemStack(Material.BARRIER, 1, "&cClose Menu", null, "&7Close this menu.."),
@@ -67,16 +50,16 @@ public class AuraMenu implements FancyMenuLoader.FancyMenu {
 
     @Override
     public String getName() {
-        return ChatColor.BLACK + "Fancy Aura Menu";
+        return ChatColor.BLACK + "Fancy Settings Menu";
     }
 
     @Override
     public Permission permission() {
-        return new Permission("fancy.menu.aura", "Permission to the aura fancy menu.");
+        return new Permission("fancy.menu.particle", "Permission to the particle settings menu.");
     }
 
     @Override
     public FancyMenuTheme getTheme() {
-        return FancyMenuTheme.parseTheme(this, "menu.aura");
+        return FancyMenuTheme.parseTheme(this, "menu.settings");
     }
 }

--- a/src/fancy/menu/menus/particle/AuraMenu.java
+++ b/src/fancy/menu/menus/particle/AuraMenu.java
@@ -1,4 +1,4 @@
-package fancy.menu.menus;
+package fancy.menu.menus.particle;
 
 import fancy.menu.FancyMenuLoader;
 import fancy.menu.FancyMenuTheme;
@@ -13,18 +13,18 @@ import org.bukkit.permissions.Permission;
 
 import java.util.List;
 
-public class OrbMenu implements FancyMenuLoader.FancyMenu {
+public class AuraMenu implements FancyMenuLoader.FancyMenu {
 
     private Inventory inv;
 
-    public OrbMenu() {
+    public AuraMenu() {
         this.inv = Bukkit.createInventory(null, 54, this.getName());
         this.getTheme().apply();
     }
 
     @Override
     public Integer inventoryId() {
-        return 4;
+        return FancyMenuLoader.FancyMenuIds.PARTICLE_AURA.getId();
     }
 
     @Override
@@ -35,7 +35,7 @@ public class OrbMenu implements FancyMenuLoader.FancyMenu {
     @Override
     public Inventory getInventory() {
 
-        List<ItemStack> items = FancyUtil.generateParticleItems("orb_particle");
+        List<ItemStack> items = FancyUtil.generateParticleItems("aura_particle");
 
         int index = 0;
         for (int i = 20; i < 34; i++) {
@@ -51,7 +51,7 @@ public class OrbMenu implements FancyMenuLoader.FancyMenu {
         inv.setItem(48,
                 NBTUtil.setItemTag(
                         FancyUtil.createItemStack(Material.ARROW, 1, "&cGo Back", null, "&7Go back a menu.."),
-                        0,
+                        FancyMenuLoader.FancyMenuIds.PARTICLE.getId(),
                         "PartlyFancy", "goback"
                 ));
 
@@ -67,16 +67,16 @@ public class OrbMenu implements FancyMenuLoader.FancyMenu {
 
     @Override
     public String getName() {
-        return ChatColor.BLACK + "Fancy Orb Menu";
+        return ChatColor.BLACK + "Fancy Aura Menu";
     }
 
     @Override
     public Permission permission() {
-        return new Permission("fancy.menu.orb", "Permission to the scan fancy menu.");
+        return new Permission("fancy.menu.aura", "Permission to the aura fancy menu.");
     }
 
     @Override
     public FancyMenuTheme getTheme() {
-        return FancyMenuTheme.parseTheme(this, "menu.orb");
+        return FancyMenuTheme.parseTheme(this, "menu.aura");
     }
 }

--- a/src/fancy/menu/menus/particle/CrownMenu.java
+++ b/src/fancy/menu/menus/particle/CrownMenu.java
@@ -1,4 +1,4 @@
-package fancy.menu.menus;
+package fancy.menu.menus.particle;
 
 import fancy.menu.FancyMenuLoader;
 import fancy.menu.FancyMenuTheme;
@@ -13,18 +13,18 @@ import org.bukkit.permissions.Permission;
 
 import java.util.List;
 
-public class WingsMenu implements FancyMenuLoader.FancyMenu {
+public class CrownMenu implements FancyMenuLoader.FancyMenu {
 
     private Inventory inv;
 
-    public WingsMenu() {
+    public CrownMenu() {
         this.inv = Bukkit.createInventory(null, 54, this.getName());
         this.getTheme().apply();
     }
 
     @Override
     public Integer inventoryId() {
-        return 3;
+        return FancyMenuLoader.FancyMenuIds.PARTICLE_CROWN.getId();
     }
 
     @Override
@@ -35,7 +35,7 @@ public class WingsMenu implements FancyMenuLoader.FancyMenu {
     @Override
     public Inventory getInventory() {
 
-        List<ItemStack> items = FancyUtil.generateParticleItems("wings_particle");
+        List<ItemStack> items = FancyUtil.generateParticleItems("crown_particle");
 
         int index = 0;
         for (int i = 20; i < 34; i++) {
@@ -51,7 +51,7 @@ public class WingsMenu implements FancyMenuLoader.FancyMenu {
         inv.setItem(48,
                 NBTUtil.setItemTag(
                         FancyUtil.createItemStack(Material.ARROW, 1, "&cGo Back", null, "&7Go back a menu.."),
-                        0,
+                        FancyMenuLoader.FancyMenuIds.PARTICLE.getId(),
                         "PartlyFancy", "goback"
                 ));
 
@@ -67,16 +67,16 @@ public class WingsMenu implements FancyMenuLoader.FancyMenu {
 
     @Override
     public String getName() {
-        return ChatColor.BLACK + "Fancy Wings Menu";
+        return ChatColor.BLACK + "Fancy Crown Menu";
     }
 
     @Override
     public Permission permission() {
-        return new Permission("fancy.menu.crown", "Permission to the wings fancy menu.");
+        return new Permission("fancy.menu.crown", "Permission to the main fancy menu.");
     }
 
     @Override
     public FancyMenuTheme getTheme() {
-        return FancyMenuTheme.parseTheme(this, "menu.wings");
+        return FancyMenuTheme.parseTheme(this, "menu.crown");
     }
 }

--- a/src/fancy/menu/menus/particle/OrbMenu.java
+++ b/src/fancy/menu/menus/particle/OrbMenu.java
@@ -1,4 +1,4 @@
-package fancy.menu.menus;
+package fancy.menu.menus.particle;
 
 import fancy.menu.FancyMenuLoader;
 import fancy.menu.FancyMenuTheme;
@@ -13,18 +13,18 @@ import org.bukkit.permissions.Permission;
 
 import java.util.List;
 
-public class CrownMenu implements FancyMenuLoader.FancyMenu {
+public class OrbMenu implements FancyMenuLoader.FancyMenu {
 
     private Inventory inv;
 
-    public CrownMenu() {
+    public OrbMenu() {
         this.inv = Bukkit.createInventory(null, 54, this.getName());
         this.getTheme().apply();
     }
 
     @Override
     public Integer inventoryId() {
-        return 1;
+        return FancyMenuLoader.FancyMenuIds.PARTICLE_ORB.getId();
     }
 
     @Override
@@ -35,7 +35,7 @@ public class CrownMenu implements FancyMenuLoader.FancyMenu {
     @Override
     public Inventory getInventory() {
 
-        List<ItemStack> items = FancyUtil.generateParticleItems("crown_particle");
+        List<ItemStack> items = FancyUtil.generateParticleItems("orb_particle");
 
         int index = 0;
         for (int i = 20; i < 34; i++) {
@@ -51,7 +51,7 @@ public class CrownMenu implements FancyMenuLoader.FancyMenu {
         inv.setItem(48,
                 NBTUtil.setItemTag(
                         FancyUtil.createItemStack(Material.ARROW, 1, "&cGo Back", null, "&7Go back a menu.."),
-                        0,
+                        FancyMenuLoader.FancyMenuIds.PARTICLE.getId(),
                         "PartlyFancy", "goback"
                 ));
 
@@ -67,16 +67,16 @@ public class CrownMenu implements FancyMenuLoader.FancyMenu {
 
     @Override
     public String getName() {
-        return ChatColor.BLACK + "Fancy Crown Menu";
+        return ChatColor.BLACK + "Fancy Orb Menu";
     }
 
     @Override
     public Permission permission() {
-        return new Permission("fancy.menu.crown", "Permission to the main fancy menu.");
+        return new Permission("fancy.menu.orb", "Permission to the scan fancy menu.");
     }
 
     @Override
     public FancyMenuTheme getTheme() {
-        return FancyMenuTheme.parseTheme(this, "menu.crown");
+        return FancyMenuTheme.parseTheme(this, "menu.orb");
     }
 }

--- a/src/fancy/menu/menus/particle/WingsMenu.java
+++ b/src/fancy/menu/menus/particle/WingsMenu.java
@@ -1,4 +1,4 @@
-package fancy.menu.menus;
+package fancy.menu.menus.particle;
 
 import fancy.menu.FancyMenuLoader;
 import fancy.menu.FancyMenuTheme;
@@ -8,20 +8,23 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.permissions.Permission;
 
-public class MainMenu implements FancyMenuLoader.FancyMenu {
+import java.util.List;
+
+public class WingsMenu implements FancyMenuLoader.FancyMenu {
 
     private Inventory inv;
 
-    public MainMenu() {
+    public WingsMenu() {
         this.inv = Bukkit.createInventory(null, 54, this.getName());
         this.getTheme().apply();
     }
 
     @Override
     public Integer inventoryId() {
-        return FancyMenuLoader.FancyMenuIds.MAIN.getId();
+        return FancyMenuLoader.FancyMenuIds.PARTICLE_WINGS.getId();
     }
 
     @Override
@@ -31,23 +34,32 @@ public class MainMenu implements FancyMenuLoader.FancyMenu {
 
     @Override
     public Inventory getInventory() {
-        inv.setItem(20,
+
+        List<ItemStack> items = FancyUtil.generateParticleItems("wings_particle");
+
+        int index = 0;
+        for (int i = 20; i < 34; i++) {
+
+            inv.setItem(i, items.get(index));
+
+            index++;
+            if (i == 24) {
+                i = 28;
+            }
+        }
+
+        inv.setItem(48,
                 NBTUtil.setItemTag(
-                        FancyUtil.createItemStack(Material.BREWING_STAND, 1, "&bParticle Effects", null, "&7Open up the particle effects."),
+                        FancyUtil.createItemStack(Material.ARROW, 1, "&cGo Back", null, "&7Go back a menu.."),
                         FancyMenuLoader.FancyMenuIds.PARTICLE.getId(),
-                        "PartlyFancy", "openinv"
+                        "PartlyFancy", "goback"
                 ));
+
         inv.setItem(49,
                 NBTUtil.setItemTag(
                         FancyUtil.createItemStack(Material.BARRIER, 1, "&cClose Menu", null, "&7Close this menu.."),
                         "null",
                         "PartlyFancy", "close"
-                ));
-        inv.setItem(50,
-                NBTUtil.setItemTag(
-                        FancyUtil.createItemStack(Material.COMPARATOR, 1, "&aYour Settings", null, "&7Open the settings menu.."),
-                        FancyMenuLoader.FancyMenuIds.SETTINGS.getId(),
-                        "PartlyFancy", "openinv"
                 ));
 
         return this.inv;
@@ -55,16 +67,16 @@ public class MainMenu implements FancyMenuLoader.FancyMenu {
 
     @Override
     public String getName() {
-        return ChatColor.BLACK + "Fancy Main Menu";
+        return ChatColor.BLACK + "Fancy Wings Menu";
     }
 
     @Override
     public Permission permission() {
-        return new Permission("fancy.menu.main", "Permission to the main fancy menu.");
+        return new Permission("fancy.menu.crown", "Permission to the wings fancy menu.");
     }
 
     @Override
     public FancyMenuTheme getTheme() {
-        return FancyMenuTheme.parseTheme(this, "menu.main");
+        return FancyMenuTheme.parseTheme(this, "menu.wings");
     }
 }

--- a/src/fancy/menu/themes/Rainbow.java
+++ b/src/fancy/menu/themes/Rainbow.java
@@ -3,6 +3,7 @@ package fancy.menu.themes;
 import fancy.PartlyFancy;
 import fancy.menu.FancyMenuLoader;
 import fancy.menu.FancyMenuTheme;
+import fancy.menu.themes.types.MultiColor;
 import fancy.util.FancyUtil;
 import fancy.util.NBTUtil;
 import org.bukkit.Bukkit;
@@ -10,31 +11,19 @@ import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitRunnable;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 
-public class Rainbow implements FancyMenuTheme {
+public class Rainbow implements FancyMenuTheme, MultiColor {
 
     private FancyMenuLoader.FancyMenu host;
     private List<Material> items;
     private int task;
 
-    /**
-     * Create new theme object for an inventory
-     * @param hostInventory Inventory to host this
-     * @param materials
-     * @param omit
-     */
-    public Rainbow(FancyMenuLoader.FancyMenu hostInventory, Material[] materials, boolean omit) {
-        this.host = hostInventory;
-        this.items = Arrays.asList(materials);
-    }
-
-    public Rainbow(FancyMenuLoader.FancyMenu hostInventory, List<Material> materials, boolean omit) {
-        this.host = hostInventory;
-        this.items = materials;
-    }
+    private boolean init;
+    public Rainbow(boolean init) {
+        this.init = init;
+    };
 
     @Override
     public String name() {
@@ -69,7 +58,24 @@ public class Rainbow implements FancyMenuTheme {
     }
 
     @Override
-    public boolean isStatic() {
-        return true;
+    public Material[] item() {
+        return (Material[]) this.items.toArray();
+    }
+
+    @Override
+    public FancyMenuTheme setItems(List<Material> materials) {
+        this.items = materials;
+        return this;
+    }
+
+    @Override
+    public FancyMenuLoader.FancyMenu menu() {
+        return this.host;
+    }
+
+    @Override
+    public FancyMenuTheme setMenu(FancyMenuLoader.FancyMenu menu) {
+        this.host = menu;
+        return this;
     }
 }

--- a/src/fancy/menu/themes/Snake.java
+++ b/src/fancy/menu/themes/Snake.java
@@ -1,0 +1,44 @@
+package fancy.menu.themes;
+
+import fancy.menu.FancyMenuLoader;
+import fancy.menu.FancyMenuTheme;
+import fancy.menu.themes.types.Static;
+import org.bukkit.Material;
+
+public class Snake implements FancyMenuTheme, Static {
+
+    @Override
+    public String name() {
+        return "SNAKE";
+    }
+
+    @Override
+    public void apply() {
+
+    }
+
+    @Override
+    public void clear() {
+
+    }
+
+    @Override
+    public FancyMenuLoader.FancyMenu menu() {
+        return null;
+    }
+
+    @Override
+    public FancyMenuTheme setMenu(FancyMenuLoader.FancyMenu menu) {
+        return null;
+    }
+
+    @Override
+    public Material item() {
+        return null;
+    }
+
+    @Override
+    public FancyMenuTheme setItem(Material material) {
+        return null;
+    }
+}

--- a/src/fancy/menu/themes/Solid.java
+++ b/src/fancy/menu/themes/Solid.java
@@ -2,30 +2,25 @@ package fancy.menu.themes;
 
 import fancy.menu.FancyMenuLoader;
 import fancy.menu.FancyMenuTheme;
+import fancy.menu.themes.types.Static;
 import fancy.util.FancyUtil;
 import fancy.util.NBTUtil;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
-public class Static implements FancyMenuTheme {
+public class Solid implements FancyMenuTheme, Static {
 
     private FancyMenuLoader.FancyMenu host;
     private Material item;
 
-    /**
-     * Create new theme object for an inventory
-     * @param hostInventory Inventory to host this
-     * @param material
-     * @param omit
-     */
-    public Static(FancyMenuLoader.FancyMenu hostInventory, Material material, boolean omit) {
-        this.host = hostInventory;
-        this.item = material;
+    private boolean init;
+    public Solid(boolean init) {
+        this.init = init;
     }
 
     @Override
     public String name() {
-        return "STATIC";
+        return "SOLID";
     }
 
     @Override
@@ -54,7 +49,24 @@ public class Static implements FancyMenuTheme {
     }
 
     @Override
-    public boolean isStatic() {
-        return true;
+    public Material item() {
+        return this.item;
+    }
+
+    @Override
+    public FancyMenuTheme setItem(Material item) {
+        this.item = item;
+        return this;
+    }
+
+    @Override
+    public FancyMenuLoader.FancyMenu menu() {
+        return this.host;
+    }
+
+    @Override
+    public FancyMenuTheme setMenu(FancyMenuLoader.FancyMenu menu) {
+        this.host = menu;
+        return this;
     }
 }

--- a/src/fancy/menu/themes/types/MultiColor.java
+++ b/src/fancy/menu/themes/types/MultiColor.java
@@ -1,0 +1,14 @@
+package fancy.menu.themes.types;
+
+import fancy.menu.FancyMenuTheme;
+import org.bukkit.Material;
+
+import java.util.List;
+
+public interface MultiColor {
+
+    Material[] item();
+
+    FancyMenuTheme setItems(List<Material> materials);
+
+}

--- a/src/fancy/menu/themes/types/Static.java
+++ b/src/fancy/menu/themes/types/Static.java
@@ -1,0 +1,12 @@
+package fancy.menu.themes.types;
+
+import fancy.menu.FancyMenuTheme;
+import org.bukkit.Material;
+
+public interface Static {
+
+    Material item();
+
+    FancyMenuTheme setItem(Material material);
+
+}

--- a/src/fancy/util/FancyUtil.java
+++ b/src/fancy/util/FancyUtil.java
@@ -40,22 +40,24 @@ public class FancyUtil {
 
         ItemMeta meta = itemStack.getItemMeta();
 
-        // Display name
-        if (name != null && name.length() != 0) {
-            meta.setDisplayName(ChatColor.translateAlternateColorCodes('&', name));
+        if (meta != null) {
+            // Display name
+            if (name != null && name.length() != 0) {
+                meta.setDisplayName(ChatColor.translateAlternateColorCodes('&', name));
+            }
+
+            // Lore
+            if (lore != null && lore.length != 0) {
+                List<String> loreLines = new ArrayList<>();
+
+                Arrays.asList(lore).forEach(line -> {
+                    loreLines.add(ChatColor.translateAlternateColorCodes('&', line));
+                });
+                meta.setLore(loreLines);
+            }
+
+            itemStack.setItemMeta(meta);
         }
-
-        // Lore
-        if (lore != null && lore.length != 0) {
-            List<String> loreLines = new ArrayList<>();
-
-            Arrays.asList(lore).forEach(line -> {
-                loreLines.add(ChatColor.translateAlternateColorCodes('&', line));
-            });
-            meta.setLore(loreLines);
-        }
-
-        itemStack.setItemMeta(meta);
 
         return itemStack;
     }

--- a/src/fancy/util/Particles.java
+++ b/src/fancy/util/Particles.java
@@ -1,15 +1,22 @@
 package fancy.util;
 
 import com.sun.istack.internal.NotNull;
+import fancy.FancyPlayer;
 import fancy.util.particlelib.ParticleEffect;
 import fancy.util.particlelib.data.color.NoteColor;
 import fancy.util.particlelib.data.color.RegularColor;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.craftbukkit.libs.jline.internal.Nullable;
+import org.bukkit.entity.Player;
 
 import java.awt.*;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
+
+import static java.util.stream.Collectors.toCollection;
 
 
 public enum Particles {
@@ -64,6 +71,33 @@ public enum Particles {
         this.spam = spam;
         this.item = item;
         this.description = description;
+    }
+
+    /**
+     * Display the particle at a specific location
+     * @param fp FancyPlayer attached to the particle display event
+     * @param loc Location to display particle
+     * @param amt Amount of the particle to display. (If particle is spammy, amount fixed to 2)
+     */
+    public void display(FancyPlayer fp, Location loc, int amt) {
+        int amount = (this.spam ? 2 : amt);
+
+        List<Player> playersToShowTo = Bukkit.getOnlinePlayers().stream().collect(toCollection(ArrayList::new));
+
+        if (!fp.canSeeOwnParticles) {
+            playersToShowTo.remove(fp.getPlayer());
+        }
+
+
+        Random r = FancyUtil.RANDOM;
+        if (this.colorable && this.effect != ParticleEffect.NOTE) {
+            RegularColor c = new RegularColor(new Color(r.nextInt(255), r.nextInt(255), r.nextInt(255)));
+            this.effect.display(loc, 0, 0, 0, 0, amount, c, playersToShowTo);
+        } else if (this.colorable && this.effect == ParticleEffect.NOTE) {
+            this.effect.display(loc, 0, 0, 0, 0, amount, NoteColor.random(), playersToShowTo);
+        } else {
+            this.effect.display(loc, playersToShowTo);
+        }
     }
 
     /**


### PR DESCRIPTION
- IDs for Menus are now inside of an enum under FancyMenuLoader instead of hardcoded throughout the plugin
- Changed structure for FancyMenuTheme to give it more modular design
- Themes now implement either 'Static' or 'Multi-Color'
- Renamed the "Static" theme to "Solid"
- Added the ability to disable seeing your own particles (Only hardcoded, not in a GUI or command yet)
- Changed overall Project structure